### PR TITLE
Choose the default editor based on environment (Closes #2)

### DIFF
--- a/src/functions/install_package.py
+++ b/src/functions/install_package.py
@@ -12,8 +12,8 @@ def install_package(mpr_url, packages, operation_string, application_name, appli
 
 	from functions.get_srcinfo_value import get_srcinfo_value    # REMOVE AT PACKAGING
 
-	# Choose an editor command accordin to user's preferences
-	editor = os.environ.get('VISUAL', os.environ.get('EDITOR', '/usr/bin/editor'))
+	# Choose an editor command according to user's preferences
+	editor = environ.get('VISUAL', environ.get('EDITOR', '/usr/bin/editor'))
 
 	# Make request to MPR
 	rpc_request_arguments = ""

--- a/src/functions/install_package.py
+++ b/src/functions/install_package.py
@@ -1,6 +1,3 @@
-from os import environ
-
-
 def install_package(mpr_url, packages, operation_string, application_name, application_version):
 	import requests
 	import json
@@ -13,7 +10,7 @@ def install_package(mpr_url, packages, operation_string, application_name, appli
 	from functions.get_srcinfo_value import get_srcinfo_value    # REMOVE AT PACKAGING
 
 	# Choose an editor command according to user's preferences
-	editor = environ.get('VISUAL', environ.get('EDITOR', '/usr/bin/editor'))
+	editor = os.environ.get('VISUAL', os.environ.get('EDITOR', '/usr/bin/editor'))
 
 	# Make request to MPR
 	rpc_request_arguments = ""

--- a/src/functions/install_package.py
+++ b/src/functions/install_package.py
@@ -1,3 +1,6 @@
+from os import environ
+
+
 def install_package(mpr_url, packages, operation_string, application_name, application_version):
 	import requests
 	import json
@@ -8,6 +11,9 @@ def install_package(mpr_url, packages, operation_string, application_name, appli
 	import time
 
 	from functions.get_srcinfo_value import get_srcinfo_value    # REMOVE AT PACKAGING
+
+	# Choose an editor command accordin to user's preferences
+	editor = os.environ.get('VISUAL', os.environ.get('EDITOR', '/usr/bin/editor'))
 
 	# Make request to MPR
 	rpc_request_arguments = ""
@@ -183,7 +189,7 @@ def install_package(mpr_url, packages, operation_string, application_name, appli
 			for j in pathlib.Path("./").glob('**/*'):
 
 				if bool(re.match('^\.git/', str(j))) == False and os.path.isfile(j) == True and bool(str(j) != '.SRCINFO') == True:
-					os.system(f"nano '{j}'")
+					os.system(f"{editor} '{j}'")
 
 			time.sleep(1)
 


### PR DESCRIPTION
See #2 
Choose the default based on environment, in the following order of precedence
1. `VISUAL`
2. `EDITOR`
3. `/usr/bin/editor`


This is the acceptable behavior according to debian policy:
https://www.debian.org/doc/debian-policy/ch-customized-programs.html#editors-and-pagers