### PR TITLE
replacing `quit()` with `sys.exit()`

### DIFF
--- a/.drone/scripts/create-release.py
+++ b/.drone/scripts/create-release.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+import sys
 from os import environ
 from github import Github
 from github.GithubException import BadCredentialsException
@@ -29,14 +31,14 @@ for i in [[pkgver, "pkgver"], [pkgrel, "pkgrel"]]:
         missing_var = True
 
 if missing_var:
-    exit(1)
+    sys.exit(1)
 
 pkgver = pkgver.lstrip("\tpkgver = ")
 pkgrel = pkgrel.lstrip("\tpkgrel = ")
 
 if github_api_key is None:
     print("ERROR: Environment variable 'github_api_key' isn't set.")
-    exit(1)
+    sys.exit(1)
 
 client = Github(github_api_key)
 
@@ -44,7 +46,7 @@ try:
     client.get_user().name
 except BadCredentialsException:
     print("ERROR: Invalid credentials provided.")
-    exit(1)
+    sys.exit(1)
 
 # Create the release.
 tag = f"v{pkgver}-{pkgrel}"

--- a/tap/arg_check.py
+++ b/tap/arg_check.py
@@ -1,5 +1,5 @@
 import re
-from sys import argv
+import sys
 
 from tap import cfg
 from tap.help_menu import help_menu
@@ -22,7 +22,7 @@ def _split_args(args):
 def arg_check():
     options = []
 
-    for i in _split_args(argv[1:]):
+    for i in _split_args(sys.argv[1:]):
         if re.match("^[a-z0-9][a-z0-9-]*$", i) is not None:
             if cfg.operation is None:
                 cfg.operation = i
@@ -44,7 +44,7 @@ def arg_check():
     elif cfg.operation not in cfg.available_commands:
         message.error(f"Invalid command '{cfg.operation}'.")
         message.error(f"See '{cfg.application_name} --help' for available commands.")
-        exit(1)
+        sys.exit(1)
 
     # Process sub-command arguments.
     opts = cfg.command_options[cfg.operation]
@@ -65,7 +65,7 @@ def arg_check():
         message.error(
             f"See '{cfg.application_name} {cfg.operation} --help' for available options."
         )
-        exit(1)
+        sys.exit(1)
 
     for i in ("-h", "--help"):
         if i in cfg.options:
@@ -74,11 +74,11 @@ def arg_check():
     # Check if a command recieved argument when it was/wasn't supposed to.
     if (cfg.operation in cfg.requires_arguments) and (cfg.packages == []):
         message.error(f"Command '{cfg.operation}' requires arguments.")
-        exit(1)
+        sys.exit(1)
     elif (
         (cfg.operation not in cfg.requires_arguments)
         and (cfg.operation not in cfg.optional_arguments)
         and (cfg.packages != [])
     ):
         message.error(f"Command '{cfg.operation}' doesn't take arguments.")
-        exit(1)
+        sys.exit(1)

--- a/tap/builddir_del_error.py
+++ b/tap/builddir_del_error.py
@@ -6,4 +6,3 @@ def builddir_del_error(i, path, j):
 
     msg = message.error(f"Path '{path}' was unable to be deleted.", value_return=True)
     raise newline_error_exception(msg)
-    exit(1)

--- a/tap/get_editor_name.py
+++ b/tap/get_editor_name.py
@@ -1,5 +1,6 @@
 # Credits to @vyashole (GitHub) for the idea to implement this.
 # See 'https://github.com/hwittenborn/tap/issues/2' for more info.
+import sys
 from tap import cfg
 
 
@@ -25,6 +26,6 @@ def get_editor_name():
 
     if which(editor_name) is None:
         message("error", f"Couldn't find editor '{editor_name}'.")
-        quit(1)
+        sys.exit(1)
 
     cfg.editor_name = editor_name

--- a/tap/help_menu.py
+++ b/tap/help_menu.py
@@ -1,3 +1,4 @@
+import sys
 from tap import cfg
 
 
@@ -21,7 +22,7 @@ def _print_formatted_args(args):
     result_string = sorted(result_string, key=str.casefold)
 
     print("".join(result_string), end="")
-    exit()
+    sys.exit()
 
     result_string.sort()
     print("".join(result_string), end="")
@@ -71,4 +72,4 @@ def help_menu(**args):
     )
 
     if args.get("exit", True):
-        exit(0)
+        sys.exit(0)

--- a/tap/install.py
+++ b/tap/install.py
@@ -1,3 +1,4 @@
+import sys
 from os import chdir, makedirs, mkdir
 from os.path import exists
 from shutil import rmtree
@@ -37,7 +38,7 @@ def _run_pre_transaction():
                 message.error(
                     f"Please check '{build_dir}', and delete it yourself if you know it is safe to do so."
                 )
-                exit(1)
+                sys.exit(1)
 
             msg = message.info(
                 "Removing old build directory...",
@@ -58,7 +59,7 @@ def _run_pre_transaction():
             message.error(
                 f"Make sure the parent directories of '{build_dir}' are writable and try again."
             )
-            exit(1)
+            sys.exit(1)
 
         # Clone packages.
         chdir(build_dir)
@@ -126,6 +127,6 @@ def install():
         message.error("Couldn't find the following packages:")
         for i in missing_packages:
             message.error2(i)
-        exit(1)
+        sys.exit(1)
 
     _run_pre_transaction()

--- a/tap/parse_srcinfo.py
+++ b/tap/parse_srcinfo.py
@@ -1,3 +1,4 @@
+import sys
 from tap import cfg
 from tap.exceptions import newline_error_exception
 from tap.message import message
@@ -59,7 +60,7 @@ def parse_srcinfo(path):
             value = " = ".join(args[1:])
         except IndexError:
             message.error("Error parsing SRCINFO file under '{path}'.")
-            exit(1)
+            sys.exit(1)
 
         try:
             current_dict[key] += [value]
@@ -89,7 +90,7 @@ def parse_srcinfo(path):
             bad_file = True
 
     if bad_file:
-        exit(1)
+        sys.exit(1)
 
     # Parse distro dependencies properly.
     for dependency in [

--- a/tap/review_build_files.py
+++ b/tap/review_build_files.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 from os import chdir
 from subprocess import PIPE
@@ -58,6 +59,6 @@ def review_build_files():
                     message.error(
                         f"Command '{cfg.editor_name} -- {file}' didn't finish succesfully."
                     )
-                    exit(0)
+                    sys.exit(0)
 
             sleep(0.5)

--- a/tap/root_check.py
+++ b/tap/root_check.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 from os import environ
 
@@ -13,7 +14,7 @@ def root_check():
             "Tap needs to run under sudo(8) in order to modify packages on your system."
         )
         message.error("Please run Tap under sudo(8) and try again.")
-        exit(1)
+        sys.exit(1)
 
     command = subprocess.run(
         ["sudo", "-nu", f"#{sudo_uid}", "true"],
@@ -23,6 +24,6 @@ def root_check():
 
     if command.returncode != 0:
         message.error(f"Couldn't obtain permissions to run under UID '{sudo_uid}'.")
-        exit(1)
+        sys.exit(1)
 
     cfg.build_user = sudo_uid

--- a/tap/run_loading_function.py
+++ b/tap/run_loading_function.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -21,4 +22,4 @@ def run_loading_function(message, function, *args, **kwargs):
     except tap.exceptions.newline_error_exception as e:
         msg = e.args[0].strip()
         print(msg)
-        exit(1)
+        sys.exit(1)

--- a/tap/run_transaction.py
+++ b/tap/run_transaction.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 from os import chdir
 from shutil import copy2
@@ -64,7 +65,7 @@ def _install_apt_packages(**kwargs):
         )
         for i in to_remove_essential:
             message.error2(i)
-        exit(1)
+        sys.exit(1)
 
     print(colors.bold)
 
@@ -113,7 +114,7 @@ def _install_apt_packages(**kwargs):
     print(f"{colors.normal}", end="")
 
     if (len_to_install + len_to_upgrade + len_to_downgrade + len_to_remove) == 0:
-        exit(0)
+        sys.exit(0)
 
     print()
     msg = message.question(
@@ -122,7 +123,7 @@ def _install_apt_packages(**kwargs):
     response = input(msg).lower()
 
     if response not in ("", "y"):
-        exit(1)
+        sys.exit(1)
 
     # Prompt the user to review build files.
     if show_to_build:
@@ -153,7 +154,7 @@ def _install_apt_packages(**kwargs):
 
         if result == cfg.apt_pkgman.RESULT_FAILED:
             message.error("Failed installing packages.")
-            exit(1)
+            sys.exit(1)
 
 
 def run_transaction():
@@ -218,7 +219,7 @@ def run_transaction():
 
                 if response != "n":
                     message.error("Aborting...")
-                    exit(1)
+                    sys.exit(1)
 
                 else:
                     message.info("Continuing with builds...")

--- a/tap/update.py
+++ b/tap/update.py
@@ -1,6 +1,7 @@
+import sys
 import json
-
 import requests
+
 from tap import cfg
 from tap.apt_fetch_packages import apt_fetch_packages
 from tap.exceptions import newline_error_exception
@@ -71,4 +72,4 @@ def update():
         message.info(
             f"{upgradeable} packages can be upgraded. Run 'tap list --upgradable' to see them."
         )
-    exit(0)
+    sys.exit(0)


### PR DESCRIPTION
`quit()` should not be used in production code because it is only meant to be used in the interactive mode of the interpreter